### PR TITLE
FIX: First load app break bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,13 @@ Suggested fix as per the discussion:
 - Added "preload" param to Inter variable declaration
 - Seemed to clear it up, will check on this in future.
 
+## [0.2.0] 
+## 2023-09-22 Base functionality
+
+### changed
+  - ~/src/app/_lib/_hooks/getLocalStorage.tsx
+    - Fixed small bug where app brakes when starting for the first time and or when the localStorage doesnt contain an todoList key.
+
 ## [0.1.0]
 ## 2023-07-11 Cleanup Cont.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "todo_app_local",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src/app/_lib/_hooks/getLocalStorage.tsx
+++ b/src/app/_lib/_hooks/getLocalStorage.tsx
@@ -7,10 +7,13 @@
  */
 const getLocalStorage = (key: string) => {
   if (typeof window !== "undefined") {
-    const parsed = JSON.parse(window.localStorage.getItem(key)!)
-    return parsed
+    if (window.localStorage.getItem(key) === null) {
+      return [{complete: true, completeDate: "2030-09-02", desc: "Test", deadline: "2040-09-20", id: "Test1", title: "Test1"}, {complete: false, completeDate: "2030-09-02", desc: "Test", deadline: "2040-09-20",id: "Test2", title: "Test2"}]
+    } else {
+      return JSON.parse(window.localStorage.getItem(key)!)
+    }
   } else {
-    return []
+    return [{complete: true, completeDate: "2030-09-02", desc: "Test", deadline: "2040-09-20", id: "Test1", title: "Test1"}, {complete: false, completeDate: "2030-09-02", desc: "Test", deadline: "2040-09-20",id: "Test2", title: "Test2"}]
   }
 }
 


### PR DESCRIPTION
Has a check to load a default set of todos incase localstorage is empty.